### PR TITLE
Fix sandboxed iframe security error

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -55,7 +55,12 @@ function deprecate (fn, msg) {
  */
 
 function config (name) {
-  if (!global.localStorage) return false;
+  // accessing global.localStorage can trigger a DOMException in sandboxed iframes
+  try {
+    if (!global.localStorage) return false;
+  } catch (_) {
+    return false;
+  }
   var val = global.localStorage[name];
   if (null == val) return false;
   return String(val).toLowerCase() === 'true';


### PR DESCRIPTION
Handle possibility that accessing `global.localStorage` can trigger a DOMException in sandboxed iframes.
Fixes #2
