### PR TITLE
localStorage is not available in Chrome packaged apps

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -56,8 +56,9 @@ function deprecate (fn, msg) {
 
 function config (name) {
   // accessing global.localStorage can trigger a DOMException in sandboxed iframes
+  // or generate a failure message in Google Chrome apps
   try {
-    if (!global.localStorage) return false;
+    if ((global.chrome && global.chrome.app) || !global.localStorage) return false;
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
In Chrome packaged apps "deprecate" generates an error message:
"window.localStorage is not available in packaged apps. Use chrome.storage.local instead."

I created a simple example based on the official 'hello world' example
https://github.com/pmorjan/chrome-app-samples/commit/fc8a3b257339c5538c32c7e42094f3028c865910
Thanks
